### PR TITLE
Fixed broken links to non-existing rebar3 plugins URLs.

### DIFF
--- a/src/intro/rebar3.md
+++ b/src/intro/rebar3.md
@@ -15,8 +15,8 @@ Rebar3 will:
 
 Rebar3 is also a self-contained Erlang script. It is easy to distribute or
 embed directly in a project. Tasks or behaviours can be modified or expanded
-with a [plugin system](https://www.rebar3.org/docs/using-available-plugins)
-[flexible enough](https://www.rebar3.org/docs/plugins) that even other languages
+with a [plugin system](https://www.rebar3.org/docs/configuration/plugins/#recommended-plugins)
+[flexible enough](https://www.rebar3.org/docs/configuration/plugins) that even other languages
 on the Erlang VM will use it as a build tool.
 
 The [rebar3 site](https://www.rebar3.org/docs/getting-started#installing-binary) provides some nice instructions on installing `rebar3`.


### PR DESCRIPTION
The URLs used originally do not exist at this time.  I did not find something resembling them.
I assume the rebar3 manual layout was re-organized after this doc was written.
I replaced the URLs with the current locations of rebar3 plugins docs, trying to
map to the original intent.